### PR TITLE
Media count UnWatched & Autoscroll disable

### DIFF
--- a/16x9/Includes_Furniture.xml
+++ b/16x9/Includes_Furniture.xml
@@ -261,11 +261,14 @@
         <value>$LOCALIZE[15100]</value>
     </variable>
     <variable name="Furniture_Counter_Movies">
-        <value condition="IntegerGreaterThan(Window(home).Property(Movies.Count),0)">[COLOR=$VAR[HighlightColor2]]$INFO[Window(home).Property(Movies.Count)][/COLOR] $LOCALIZE[20342]</value>
+        <value condition="!Skin.HasSetting(header.mainheadercount) + IntegerGreaterThan(Window(home).Property(Movies.Count),0)">[COLOR=$VAR[HighlightColor2]]$INFO[Window(home).Property(Movies.Count)][/COLOR] $LOCALIZE[20342]</value>
+		<value condition="Skin.HasSetting(header.mainheadercount) + IntegerGreaterThan(Window(home).Property(Movies.UnWatched),0)">[COLOR=$VAR[HighlightColor2]]$INFO[Window(home).Property(Movies.UnWatched)][/COLOR] $LOCALIZE[16101] $LOCALIZE[20342]</value>
     </variable>
     <variable name="Furniture_Counter_Episodes">
-        <value condition="IntegerGreaterThan(Window(home).Property(Episodes.Count),0) + IntegerGreaterThan(Window(home).Property(Movies.Count),0)">  •  [COLOR=$VAR[HighlightColor2]]$INFO[Window(home).Property(Episodes.Count)][/COLOR] $LOCALIZE[20360]</value>
-        <value condition="IntegerGreaterThan(Window(home).Property(Episodes.Count),0) + !IntegerGreaterThan(Window(home).Property(Movies.Count),0)">[COLOR=$VAR[HighlightColor2]]$INFO[Window(home).Property(Episodes.Count)][/COLOR] $LOCALIZE[20360]</value>
+        <value condition="!Skin.HasSetting(header.mainheadercount) + IntegerGreaterThan(Window(home).Property(Episodes.Count),0) + IntegerGreaterThan(Window(home).Property(Movies.Count),0)">  •  [COLOR=$VAR[HighlightColor2]]$INFO[Window(home).Property(Episodes.Count)][/COLOR] $LOCALIZE[20360]</value>
+        <value condition="Skin.HasSetting(header.mainheadercount) + IntegerGreaterThan(Window(home).Property(Movies.UnWatched),0)">  •  [COLOR=$VAR[HighlightColor2]]$INFO[Window(home).Property(Episodes.UnWatched)][/COLOR] $LOCALIZE[16101] $LOCALIZE[20342]</value>
+        <value condition="!Skin.HasSetting(header.mainheadercount) + IntegerGreaterThan(Window(home).Property(Episodes.Count),0) + !IntegerGreaterThan(Window(home).Property(Movies.Count),0)">[COLOR=$VAR[HighlightColor2]]$INFO[Window(home).Property(Episodes.Count)][/COLOR] $LOCALIZE[20360]</value>
+		<value condition="Skin.HasSetting(header.mainheadercount) + IntegerGreaterThan(Window(home).Property(Movies.UnWatched),0)">[COLOR=$VAR[HighlightColor2]]$INFO[Window(home).Property(Episodes.UnWatched)][/COLOR] $LOCALIZE[16101] $LOCALIZE[20342]</value>
     </variable>
     <variable name="Furniture_Counter_Songs">
         <value condition="IntegerGreaterThan(Window(home).Property(Music.SongsCount),0) + [IntegerGreaterThan(Window(home).Property(Episodes.Count),0) | IntegerGreaterThan(Window(home).Property(Movies.Count),0)]">  •  [COLOR=$VAR[HighlightColor2]]$INFO[Window(home).Property(Music.SongsCount)][/COLOR] $LOCALIZE[134]</value>

--- a/16x9/SkinSettings.xml
+++ b/16x9/SkinSettings.xml
@@ -142,6 +142,17 @@
                         <include>Defs_OptionButton</include>
                         <visible>ControlGroup(8000).HasFocus(8001)</visible>
                     </control>
+					<!-- Auto scroll posters -->
+					<control type="radiobutton" id="8106">
+						<width>100%</width>
+						<label>Auto scroll posters</label>
+						<radioposx>1350</radioposx>
+						<selected>Skin.HasSetting(home.widgetpostersscroll)</selected>
+						<onclick>Skin.ToggleSetting(home.widgetpostersscroll)</onclick>
+						<enable>!stringcompare(Skin.String(home.widgetposters),$LOCALIZE[31155] + !stringcompare(Skin.String(home.widgetposters),$LOCALIZE[31154]</enable>
+						<include>Defs_OptionButton</include>
+                        <visible>ControlGroup(8000).HasFocus(8001)</visible>
+					</control>
                     <!-- Widget DiscArt -->
                     <control type="radiobutton" id="8105">
                         <width>100%</width>
@@ -327,6 +338,17 @@
                         <radioposx>1350</radioposx>
                         <onclick>Skin.ToggleSetting(disable.mainheader)</onclick>
                         <selected>!Skin.HasSetting(disable.mainheader)</selected>
+                        <include>Defs_OptionButton</include>
+                        <visible>ControlGroup(8000).HasFocus(8007)</visible>
+                    </control>
+					<!-- Switch between All/Unwatched media counter -->
+                    <control type="radiobutton" id="8704">
+                        <width>100%</width>
+						<radioposx>1350</radioposx>
+						<label>31160</label>
+						<enable>!Skin.HasSetting(disable.mainheader)</enable>
+                        <onclick>Skin.ToggleSetting(header.mainheadercount)</onclick>
+						<selected>Skin.HasSetting(header.mainheadercount)</selected>
                         <include>Defs_OptionButton</include>
                         <visible>ControlGroup(8000).HasFocus(8007)</visible>
                     </control>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -581,3 +581,7 @@ msgstr ""
 msgctxt "#31159"
 msgid "Global overlay"
 msgstr ""
+
+msgctxt "#31160"
+msgid "Show unwatched count in header"
+msgstr ""


### PR DESCRIPTION
1. Added option to show only UnWatched in header count.
2. Added option to stop autoscroll posters in widget.

![screenshot011](https://cloud.githubusercontent.com/assets/110679/10220168/d4a16b9a-684d-11e5-858d-9ef141da3d2c.png)
![screenshot012](https://cloud.githubusercontent.com/assets/110679/10220170/d4a3acc0-684d-11e5-8c2f-fd05c66861ba.png)
![screenshot013](https://cloud.githubusercontent.com/assets/110679/10220169/d4a2fa96-684d-11e5-988a-1107836cdc0e.png)