### PR TITLE
Fix music playlist visibility and avoid video lookup ambiguity from script.globalsearch.

### DIFF
--- a/16x9/MyMusicNav.xml
+++ b/16x9/MyMusicNav.xml
@@ -50,7 +50,7 @@
                     <include>Defs_OptionButton</include>
                     <label>13350</label>
                     <onclick>ActivateWindow(MusicPlaylist)</onclick>
-                    <visible>IntegerGreaterThan(Playlist.Length(music),1)</visible>
+                    <visible>IntegerGreaterThan(Playlist.Length(music),0)</visible>
                 </control>
                 <!-- Party Mode -->
                 <control type="radiobutton" id="16">

--- a/16x9/script-globalsearch-infodialog.xml
+++ b/16x9/script-globalsearch-infodialog.xml
@@ -22,9 +22,9 @@
         <control type="button" id="9402">
             <visible allowhiddenfocus="true">false</visible>
             <onfocus>Action(Close)</onfocus>
-            <onfocus condition="Control.IsVisible(110)">RunScript(script.extendedinfo,info=extendedinfo,name=$INFO[Container(100).ListItem.Label])</onfocus>
-            <onfocus condition="Control.IsVisible(120)">RunScript(script.extendedinfo,info=extendedtvinfo,name=$INFO[Container(100).ListItem.Label])</onfocus>
-            <onfocus condition="Control.IsVisible(140)">RunScript(script.extendedinfo,info=extendedtvinfo,name=$INFO[Container(100).ListItem.Property(TvShowTitle)])</onfocus>
+            <onfocus condition="Control.IsVisible(110)">RunScript(script.extendedinfo,info=extendedinfo,name=$INFO[Container(100).ListItem.Label],dbid=$INFO[Container(100).ListItem.Property(dbid)])</onfocus>
+            <onfocus condition="Control.IsVisible(120)">RunScript(script.extendedinfo,info=extendedtvinfo,name=$INFO[Container(100).ListItem.Label],dbid=$INFO[Container(100).ListItem.Property(dbid)])</onfocus>
+            <onfocus condition="Control.IsVisible(140)">RunScript(script.extendedinfo,info=extendedtvinfo,name=$INFO[Container(100).ListItem.Property(TvShowTitle)],dbid=$INFO[Container(100).ListItem.Property(dbid)])</onfocus>
         </control>
 
         <control type="group">


### PR DESCRIPTION
Hi jurialmunkey,
A couple of commits:

You know I've been playing with playlists and reported some problems before. I also noticed music playlists aren't visible until two items are queued, and tracked the problem to an off-by-one in an "IntegerGreaterThan".

Also, @ronie accepted my PR to add a Property(dbid) for script.globalsearch, so I'm using it here to disambiguate videos. This is part #2 to when I suggested the video OSD "Extra Info" could use the IMDB ID to identify a film uniquely (thanks for the change, it works great!).

BTW, I noticed in both "Extra Info" and globalsearch, you avoid retrieving episode information and instead retrieve the TV show information. Is this deliberate because of some known problems?  The reason I ask is I've been trying to get episode information to work, using "script.extendedinfo, info=extendedepisodeinfo", but without success.

I posted on the script.extendedinfo forum about the problem I run into, but have no response yet. Could you take a look at this post and see what you think?
http://forum.kodi.tv/showthread.php?tid=160558&pid=2156280#pid2156280

It would be nice to have this working in E2...

Cheers.