### PR TITLE
Add playback speed control to OSD

### DIFF
--- a/16x9/Custom_1110_TempoControl.xml
+++ b/16x9/Custom_1110_TempoControl.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<window id="1110" type="dialog">
+	<defaultcontrol>11</defaultcontrol>
+	<controls>
+		<control type="group">
+			<top>0</top>
+			<centerleft>50%</centerleft>
+			<width>840</width>
+			<height>60</height>
+			<include>Animation_SlideIn</include>
+			<include>Animation_FadeOut</include>
+			<include>Dialog_Background</include>
+			<control type="label">
+				<description>Dialog header</description>
+				<left>40</left>
+				<top>15</top>
+				<width>550</width>
+				<height>30</height>
+				<aligny>center</aligny>
+				<font>font14</font>
+				<label>Playback Speed</label>
+			</control>
+			<control type="label">
+				<left>120</left>
+				<top>15</top>
+				<width>550</width>
+				<height>30</height>
+				<align>right</align>
+				<aligny>center</aligny>
+				<font>font14</font>
+				<label>$INFO[Player.playspeed]</label>
+			</control>
+			<control type="button" id="11">
+				<left>740</left>
+				<top>22</top>
+				<width>16</width>
+				<height>16</height>
+				<onleft>12</onleft>
+				<onright>12</onright>
+				<texturefocus colordiffuse="Highlight">common/16-arrow-down.png</texturefocus>
+				<texturenofocus>common/16-arrow-down.png</texturenofocus>
+				<onclick>PlayerControl(TempoDown)</onclick>
+			</control>
+			<control type="button" id="12">
+				<left>780</left>
+				<top>22</top>
+				<width>16</width>
+				<height>16</height>
+				<onleft>11</onleft>
+				<onright>11</onright>
+				<texturefocus flipy="true" colordiffuse="Highlight">common/16-arrow-down.png</texturefocus>
+				<texturenofocus flipy="true">common/16-arrow-down.png</texturenofocus>
+				<onclick>PlayerControl(TempoUp)</onclick>
+			</control>
+		</control>
+	</controls>
+</window>

--- a/16x9/Includes_Window.xml
+++ b/16x9/Includes_Window.xml
@@ -1368,9 +1368,10 @@
             <include>Defs_OSDButton</include>
         </control>
         <control type="button" id="2">
+            <description>Video Settings</description>
             <label>291</label>
             <onclick>ActivateWindow(osdvideosettings)</onclick>
-			<onup>9321</onup>
+			<onup>9314</onup>
             <include>Defs_OSDButton</include>
         </control>
         <control type="button" id="3">

--- a/16x9/Includes_Window.xml
+++ b/16x9/Includes_Window.xml
@@ -19,7 +19,7 @@
                 <height>posterh</height>
                 <include>Object_Background</include>
                 <include>Window_Hub_Widget</include>
-                
+
                 <control type="group">
                     <left>0</left>
                     <right>0</right>
@@ -1693,6 +1693,47 @@
                     </control>
                 </control>
 			</control>
+            <control type="group">
+                <visible allowhiddenfocus="true">ControlGroup(9313).HasFocus() | Control.HasFocus(2)</visible>
+                <visible>Window.IsVisible(videoosd)</visible>
+                <visible>Player.TempoEnabled</visible>
+                <bottom>64</bottom>
+                <centerleft>346</centerleft>
+                <width>320</width>
+                <height>69</height>
+                <control type="image">
+                    <description>background image</description>
+                    <left>-24</left>
+                    <right>-24</right>
+                    <top>-24</top>
+                    <bottom>-24</bottom>
+                    <bordersize>24</bordersize>
+                    <bordertexture border="24">common/24-shadow.png</bordertexture>
+                    <texture colordiffuse="DialogBG">common/white.png</texture>
+                </control>
+                <control type="grouplist" id="9313">
+                    <left>0</left>
+                    <right>0</right>
+                    <top>0</top>
+                    <bottom>0</bottom>
+                    <onup>noop</onup>
+                    <ondown>2</ondown>
+                    <onleft>2</onleft>
+                    <onright>2</onright>
+                    <itemgap>0</itemgap>
+                    <orientation>vertical</orientation>
+                    <scrolltime>200</scrolltime>
+                    <control type="button" id="9314" description="Playback Speed">
+						<width>100%</width>
+                        <height>69</height>
+						<include>Defs_OSDButton</include>
+						<label>Playback Speed</label>
+						<onclick condition="String.IsEmpty(Window(home).Property(osdinfo))">Close</onclick>
+						<onclick condition="!String.IsEmpty(Window(home).Property(osdinfo))">ClearProperty(osdinfo,home)</onclick>
+						<onclick>ActivateWindow(1110)</onclick>
+					</control>
+                </control>
+			</control>
             <!-- <control type="group">
                 <visible allowhiddenfocus="true">ControlGroup(9320).HasFocus() | Control.HasFocus(2)</visible>
                 <visible>Window.IsVisible(videoosd)</visible>
@@ -2203,7 +2244,7 @@
                 <height>16</height>
                 <visible>Player.Seeking</visible>
             </control>
-                
+
             <control type="button">
                 <visible>Player.Seeking | Player.DisplayAfterSeek | Player.Forwarding | Player.Rewinding | [Skin.HasSetting(OSDNoInfo) + Player.Caching] | !String.IsEmpty(Player.SeekNumeric)</visible>
                 <include>Animation_FadeIn</include>
@@ -2313,7 +2354,7 @@
                 <animation effect="slide" end="19" condition="Integer.IsGreater(Control.GetLabel(401),91)">Conditional</animation>
                 <animation effect="slide" end="19" condition="Integer.IsGreater(Control.GetLabel(401),92)">Conditional</animation>
             </control>
-                
+
         </control>
     </include>
 </includes>


### PR DESCRIPTION
This PR aims to add the playback speed menu that was introduced in the default Kodi 19 skin (Estuary). I am relatively new to Kodi skinning so I am not sure if the code is correct so any feedback is welcomed.