### PR TITLE
Setting Show name of unwatched episodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *~
 .gitattributes
 Thumbs.db
+/.vs

--- a/16x9/Custom_Dialog_SelectView_1110.xml
+++ b/16x9/Custom_Dialog_SelectView_1110.xml
@@ -63,7 +63,7 @@
                             <align>left</align>
                             <aligny>center</aligny>
                             <font>Font-ListInfo-Small-Bold</font>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                         </control>
                     </control>
                 </itemlayout>
@@ -100,7 +100,7 @@
                             <aligny>center</aligny>
                             <textcolor>Selected</textcolor>
                             <font>Font-ListInfo-Small-Bold</font>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                         </control>
                     </control>
                 </focusedlayout>

--- a/16x9/DialogAddonInfo.xml
+++ b/16x9/DialogAddonInfo.xml
@@ -37,7 +37,7 @@
                             <right>pad</right>
                             <height>36</height>
                             <font>Font-InfoBox-Title</font>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                         </control>
                         <control type="label">
                             <left>pad</left>
@@ -201,7 +201,7 @@
                             <include>Defs_OptionButton3</include>
                             <visible>Control.IsEnabled(12)</visible>
                         </control>
-                    
+
 
                         <!-- Configure Addon Button -->
                         <control type="button" id="9">
@@ -210,7 +210,7 @@
                             <include>Defs_OptionButton3</include>
                             <visible>Control.IsEnabled(9)</visible>
                         </control>
-                    
+
 
                         <!-- Update Addon Button -->
                         <control type="button" id="8">

--- a/16x9/DialogKeyboard.xml
+++ b/16x9/DialogKeyboard.xml
@@ -48,7 +48,7 @@
                             <height>100%</height>
                             <aligny>center</aligny>
                             <align>center</align>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                             <font>Font-RSS</font>
                         </control>
                     </control>
@@ -69,7 +69,7 @@
                             <aligny>center</aligny>
                             <align>center</align>
                             <textcolor>Selected</textcolor>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                             <font>Font-RSS</font>
                         </control>
                     </control>

--- a/16x9/DialogPVRGroupManager.xml
+++ b/16x9/DialogPVRGroupManager.xml
@@ -43,7 +43,7 @@
                                 <textcolor>ListLabel</textcolor>
                                 <font>Font-ListInfo-Small-Bold</font>
                                 <aligny>center</aligny>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                             </control>
                         </itemlayout>
                         <focusedlayout width="570" height="72">
@@ -60,7 +60,7 @@
                                 <textcolor>Selected</textcolor>
                                 <font>Font-ListInfo-Small-Bold</font>
                                 <aligny>center</aligny>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                             </control>
                         </focusedlayout>
                     </control>
@@ -92,7 +92,7 @@
                                 <textcolor>ListLabel</textcolor>
                                 <font>Font-ListInfo-Small-Bold</font>
                                 <aligny>center</aligny>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                             </control>
                         </itemlayout>
                         <focusedlayout width="570" height="72">
@@ -115,7 +115,7 @@
                                 <textcolor>Selected</textcolor>
                                 <font>Font-ListInfo-Small-Bold</font>
                                 <aligny>center</aligny>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                             </control>
                         </focusedlayout>
                     </control>
@@ -147,7 +147,7 @@
                                 <textcolor>ListLabel</textcolor>
                                 <font>Font-ListInfo-Small-Bold</font>
                                 <aligny>center</aligny>
-                                <label>$INFO[ListItem.ChannelNumberLabel,,. ]$INFO[ListItem.Label]</label>
+                                <label>$INFO[ListItem.ChannelNumberLabel,,. ]$VAR[Item_Label]</label>
                             </control>
                         </itemlayout>
                         <focusedlayout width="570" height="72">
@@ -170,7 +170,7 @@
                                 <textcolor>Selected</textcolor>
                                 <font>Font-ListInfo-Small-Bold</font>
                                 <aligny>center</aligny>
-                                <label>$INFO[ListItem.ChannelNumberLabel,,. ]$INFO[ListItem.Label]</label>
+                                <label>$INFO[ListItem.ChannelNumberLabel,,. ]$VAR[Item_Label]</label>
                             </control>
                         </focusedlayout>
                     </control>

--- a/16x9/DialogPictureInfo.xml
+++ b/16x9/DialogPictureInfo.xml
@@ -15,7 +15,7 @@
                 <bottom>bigpad</bottom>
                 <include>Dialog_Background</include>
                 <include content="Dialog_Top_IconHeader">
-                    <param name="label" value="$INFO[ListItem.Label]" />
+                    <param name="label" value="$VAR[Item_Label]" />
                     <param name="icon" value="special://skin/extras/icons/pictures.png" />
                 </include>
                 <control type="group">

--- a/16x9/DialogSubtitles.xml
+++ b/16x9/DialogSubtitles.xml
@@ -51,7 +51,7 @@
                                 <textcolor>ListLabel</textcolor>
                                 <font>Font-ListInfo-Small-Bold</font>
                                 <aligny>center</aligny>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                             </control>
                         </itemlayout>
                         <focusedlayout width="460" height="72">
@@ -67,7 +67,7 @@
                                 <textcolor>Selected</textcolor>
                                 <font>Font-ListInfo-Small-Bold</font>
                                 <aligny>center</aligny>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                             </control>
                         </focusedlayout>
                     </control>
@@ -147,7 +147,7 @@
                                 <textcolor>ListLabel</textcolor>
                                 <font>Font-ListInfo-Small-Bold</font>
                                 <aligny>center</aligny>
-                                <label>$INFO[ListItem.Label]$INFO[ListItem.Label2, - ,]</label>
+                                <label>$VAR[Item_Label]$INFO[ListItem.Label2, - ,]</label>
                             </control>
                         </itemlayout>
                         <focusedlayout width="listlinew" height="72">
@@ -212,7 +212,7 @@
                                 <textcolor>Selected</textcolor>
                                 <font>Font-ListInfo-Small-Bold</font>
                                 <aligny>center</aligny>
-                                <label>$INFO[ListItem.Label]$INFO[ListItem.Label2, - ,]</label>
+                                <label>$VAR[Item_Label]$INFO[ListItem.Label2, - ,]</label>
                             </control>
                         </focusedlayout>
                     </control>

--- a/16x9/Includes_Defs.xml
+++ b/16x9/Includes_Defs.xml
@@ -530,7 +530,7 @@
                     <textcolor>ListLabel</textcolor>
                     <align>center</align>
                     <aligny>center</aligny>
-                    <label>$INFO[ListItem.Label]</label>
+                    <label>$VAR[Item_Label]</label>
                 </control>
                 <control type="textbox">
                     <left>60</left>
@@ -571,7 +571,7 @@
                     <textcolor>Selected</textcolor>
                     <align>center</align>
                     <aligny>center</aligny>
-                    <label>$INFO[ListItem.Label]</label>
+                    <label>$VAR[Item_Label]</label>
                 </control>
                 <control type="textbox">
                     <left>60</left>

--- a/16x9/Includes_Dialog.xml
+++ b/16x9/Includes_Dialog.xml
@@ -149,7 +149,7 @@
                             </control>
                             <control type="label">
                                 <textcolor>ffddddddd</textcolor>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                                 <top>300</top>
                                 <height>30</height>
                                 <left>20</left>
@@ -191,7 +191,7 @@
                             </control>
                             <control type="label">
                                 <textcolor>ffededed</textcolor>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                                 <top>300</top>
                                 <height>30</height>
                                 <left>20</left>
@@ -382,7 +382,7 @@
                 <font>Font-ListInfo-Small</font>
                 <aligny>center</aligny>
                 <textcolor>ListLabel</textcolor>
-                <label>$INFO[ListItem.Label]</label>
+                <label>$VAR[Item_Label]</label>
             </control>
         </itemlayout>
         <focusedlayout width="460" height="82">
@@ -399,7 +399,7 @@
                 <font>Font-ListInfo-Small</font>
                 <aligny>center</aligny>
                 <textcolor>Selected</textcolor>
-                <label>$INFO[ListItem.Label]</label>
+                <label>$VAR[Item_Label]</label>
             </control>
         </focusedlayout>
     </include>
@@ -486,7 +486,7 @@
                 <font>Font-ListInfo-Small</font>
                 <aligny>center</aligny>
                 <textcolor>ListLabel</textcolor>
-                <label>$INFO[ListItem.Label]</label>
+                <label>$VAR[Item_Label]</label>
             </control>
         </itemlayout>
         <focusedlayout width="374" height="72">
@@ -503,7 +503,7 @@
                 <font>Font-ListInfo-Small</font>
                 <aligny>center</aligny>
                 <textcolor>Selected</textcolor>
-                <label>$INFO[ListItem.Label]</label>
+                <label>$VAR[Item_Label]</label>
             </control>
         </focusedlayout>
     </include>
@@ -649,7 +649,7 @@
                         <right>30</right>
                         <top>0</top>
                         <height>100%</height>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                     </control>
                     <control type="label">
                         <left>30</left>
@@ -673,7 +673,7 @@
                         <right>30</right>
                         <top>0</top>
                         <height>100%</height>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                         <textcolor>Selected</textcolor>
                     </control>
                     <control type="label">
@@ -705,7 +705,7 @@
                             <right>30</right>
                             <top>0</top>
                             <height>66%</height>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                         </control>
                         <control type="label">
                             <left>148</left>
@@ -722,7 +722,7 @@
                         <right>30</right>
                         <top>0</top>
                         <height>100%</height>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                         <visible>String.IsEmpty(ListItem.Label2)</visible>
                     </control>
                 </itemlayout>
@@ -748,7 +748,7 @@
                             <right>30</right>
                             <top>0</top>
                             <height>66%</height>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                             <textcolor>Selected</textcolor>
                         </control>
                         <control type="label">
@@ -767,7 +767,7 @@
                         <right>30</right>
                         <top>0</top>
                         <height>100%</height>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                         <visible>String.IsEmpty(ListItem.Label2)</visible>
                         <textcolor>Selected</textcolor>
                     </control>
@@ -811,7 +811,7 @@
                         <textcolor>ListLabel</textcolor>
                         <font>Font-ListInfo-Small-Bold</font>
                         <aligny>center</aligny>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                     </control>
                     <control type="label">
                         <left>bigpad</left>
@@ -838,7 +838,7 @@
                         <textcolor>Selected</textcolor>
                         <font>Font-ListInfo-Small-Bold</font>
                         <aligny>center</aligny>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                     </control>
                     <control type="label">
                         <left>bigpad</left>
@@ -893,7 +893,7 @@
                             <textcolor>ListLabel</textcolor>
                             <font>Font-ListInfo-Bold</font>
                             <aligny>center</aligny>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                         </control>
                     </control>
                 </itemlayout>
@@ -915,7 +915,7 @@
                             <textcolor>ListLabel</textcolor>
                             <font>Font-ListInfo-Bold</font>
                             <aligny>center</aligny>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                             <visible>String.IsEmpty(ListItem.Label2)</visible>
                             <visible>String.IsEmpty(ListItem.Property(character))</visible>
                             <visible>String.IsEmpty(ListItem.Property(job))</visible>
@@ -931,7 +931,7 @@
                                 <textcolor>ListLabel</textcolor>
                                 <font>Font-ListInfo-Bold</font>
                                 <aligny>center</aligny>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                             </control>
                             <control type="label">
                                 <width>100%</width>
@@ -974,7 +974,7 @@
                             <textcolor>Selected</textcolor>
                             <font>Font-ListInfo-Bold</font>
                             <aligny>center</aligny>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                         </control>
                     </control>
                 </focusedlayout>
@@ -1001,7 +1001,7 @@
                             <textcolor>Selected</textcolor>
                             <font>Font-ListInfo-Bold</font>
                             <aligny>center</aligny>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                             <visible>String.IsEmpty(ListItem.Label2)</visible>
                             <visible>String.IsEmpty(ListItem.Property(character))</visible>
                             <visible>String.IsEmpty(ListItem.Property(job))</visible>
@@ -1017,7 +1017,7 @@
                                 <textcolor>Selected</textcolor>
                                 <font>Font-ListInfo-Bold</font>
                                 <aligny>center</aligny>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                             </control>
                             <control type="label">
                                 <width>100%</width>
@@ -1100,7 +1100,7 @@
                             <right>30</right>
                             <top>0</top>
                             <height>100%</height>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                         </control>
                         <control type="label">
                             <left>30</left>
@@ -1125,7 +1125,7 @@
                             <right>30</right>
                             <top>0</top>
                             <height>100%</height>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                             <textcolor>Selected</textcolor>
                         </control>
                         <control type="label">

--- a/16x9/Includes_Furniture.xml
+++ b/16x9/Includes_Furniture.xml
@@ -442,7 +442,7 @@
                 <texture colordiffuse="LineLabel" fallback="indicator/fallback.png">$VAR[Image_AudioCodec]</texture>
             </control>
 
-            
+
 
             <!-- MPAA -->
             <control type="group">
@@ -519,7 +519,7 @@
                 <visible>!String.IsEmpty(ListItem.AlbumArtist) | !String.IsEmpty(ListItem.Album)</visible>
                 <visible>Container.Content(songs)</visible>
             </control>
-            
+
 
             <!-- Duration -->
             <control type="image">
@@ -645,7 +645,7 @@
             <visible>![Player.HasVideo | Player.HasAudio] | [Player.HasAudio + !Skin.HasSetting(background.showvisualisation)] | [Player.HasVideo + !Skin.HasSetting(background.showvideo)] | Window.IsVisible(weather)</visible>
         </control>
 
-        
+
 
         <control type="group">
             <visible>Skin.HasSetting(background.showvisualisation)</visible>
@@ -981,6 +981,7 @@
                 <label>$INFO[Player.Title]</label>
                 <aligny>top</aligny>
                 <textcolor>$VAR[Furniture_TopBar_MainLabel_Color]</textcolor>
+                <visible>Skin.HasSetting(furniture.showunwatchedepisodenames) | String.IsEmpty(VideoPlayer.Episode) | !Integer.IsLess(VideoPlayer.PlayCount,1)</visible>
             </control>
             <control type="grouplist">
                 <posx>245</posx>

--- a/16x9/Includes_Furniture.xml
+++ b/16x9/Includes_Furniture.xml
@@ -981,7 +981,7 @@
                 <label>$INFO[Player.Title]</label>
                 <aligny>top</aligny>
                 <textcolor>$VAR[Furniture_TopBar_MainLabel_Color]</textcolor>
-                <visible>Skin.HasSetting(furniture.showunwatchedepisodenames) | String.IsEmpty(VideoPlayer.Episode) | !Integer.IsLess(VideoPlayer.PlayCount,1)</visible>
+                <visible>!Skin.HasSetting(furniture.showunwatchedepisodenames) | String.IsEmpty(VideoPlayer.Episode) | !Integer.IsLess(VideoPlayer.PlayCount,1)</visible>
             </control>
             <control type="grouplist">
                 <posx>245</posx>

--- a/16x9/Includes_Home.xml
+++ b/16x9/Includes_Home.xml
@@ -167,7 +167,7 @@
                         <aligny>center</aligny>
                         <font>Font-HomeMenu</font>
                         <textcolor>HomeBarFG</textcolor>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                         <animation effect="fade" start="50" end="50" condition="true">Conditional</animation>
                     </control>
                 </itemlayout>
@@ -194,7 +194,7 @@
                         <aligny>center</aligny>
                         <font>Font-HomeMenu</font>
                         <textcolor>HomeBarFG</textcolor>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                         <animation effect="slide" start="0" end="0,-12" time="100" reversible="false">Focus</animation>
                     </control>
                     <control type="image">
@@ -271,7 +271,7 @@
                         <aligny>center</aligny>
                         <font>Font-HomeMenu</font>
                         <textcolor>HomeBarFG</textcolor>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                         <animation effect="fade" start="50" end="50" condition="true">Conditional</animation>
                     </control>
                 </itemlayout>
@@ -308,7 +308,7 @@
                         <aligny>center</aligny>
                         <font>Font-HomeMenu</font>
                         <textcolor>HomeBarFG</textcolor>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                     </control>
                     <control type="image">
                         <centerleft>85</centerleft>
@@ -332,7 +332,7 @@
                         <aligny>center</aligny>
                         <font>Font-HomeMenu</font>
                         <textcolor>HomeBarFG</textcolor>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                         <animation effect="fade" start="50" end="50" condition="true">Conditional</animation>
                     </control>
                 </itemlayout>
@@ -345,7 +345,7 @@
                         <aligny>center</aligny>
                         <font>Font-HomeMenu</font>
                         <textcolor>HomeBarFG</textcolor>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                         <animation effect="slide" start="0" end="0,-12" time="100" reversible="false">Focus</animation>
                     </control>
                     <control type="image">
@@ -479,7 +479,7 @@
                         <textcolor>ListLabel</textcolor>
                         <font>Font-ListInfo-Small</font>
                         <aligny>center</aligny>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                     </control>
                 </itemlayout>
                 <focusedlayout width="374" height="69">
@@ -495,7 +495,7 @@
                         <textcolor>Selected</textcolor>
                         <font>Font-ListInfo-Small</font>
                         <aligny>center</aligny>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                     </control>
                 </focusedlayout>
                 <content>

--- a/16x9/Includes_Label.xml
+++ b/16x9/Includes_Label.xml
@@ -42,7 +42,7 @@
     </variable>
 
     <variable name="Item_Label">
-        <value condition="!Skin.HasSetting(furniture.showunwatchedepisodenames) + Container.Content(episodes) + !String.IsEmpty(ListItem.Episode) + Integer.IsLess(ListItem.PlayCount,1)">$VAR[Episode_Key_Full]</value>
+        <value condition="Skin.HasSetting(furniture.showunwatchedepisodenames) + Container.Content(episodes) + !String.IsEmpty(ListItem.Episode) + Integer.IsLess(ListItem.PlayCount,1)">$VAR[Episode_Key_Full]</value>
         <value>$INFO[ListItem.Label]</value>
     </variable>
 

--- a/16x9/Includes_Label.xml
+++ b/16x9/Includes_Label.xml
@@ -42,7 +42,7 @@
     </variable>
 
     <variable name="Item_Label">
-        <value condition="!Skin.HasSetting(furniture.showunwatchedepisodenames) + Container.Content(episodes) + Integer.IsLess(ListItem.PlayCount,1) + !String.IsEmpty(ListItem.Episode)">$VAR[Episode_Key_Full]</value>
+        <value condition="!Skin.HasSetting(furniture.showunwatchedepisodenames) + Container.Content(episodes) + !String.IsEmpty(ListItem.Episode) + Integer.IsLess(ListItem.PlayCount,1)">$VAR[Episode_Key_Full]</value>
         <value>$INFO[ListItem.Label]</value>
     </variable>
 

--- a/16x9/Includes_Label.xml
+++ b/16x9/Includes_Label.xml
@@ -41,6 +41,11 @@
         <value>$LOCALIZE[31244]</value>
     </variable>
 
+    <variable name="Item_Label">
+        <value condition="!Skin.HasSetting(furniture.showunwatchedepisodenames) + Container.Content(episodes) + Integer.IsLess(ListItem.PlayCount,1) + !String.IsEmpty(ListItem.Episode)">$VAR[Episode_Key_Full]</value>
+        <value>$INFO[ListItem.Label]</value>
+    </variable>
+
     <variable name="Label_Duration">
         <value>$INFO[ListItem.Duration(mins),, mins]</value>
     </variable>
@@ -150,7 +155,7 @@
 
     <variable name="Label_OverlayTitle">
         <value condition="[Container.Content(episodes) | Container.Content(seasons)] + !String.IsEmpty(ListItem.TvShowTitle)">$INFO[ListItem.TvShowTitle]</value>
-        <value condition="!String.IsEmpty(ListItem.Label)">$INFO[ListItem.Label]</value>
+        <value condition="!String.IsEmpty(ListItem.Label)">$VAR[Item_Label]</value>
         <value condition="!String.IsEmpty(ListItem.Title)">$INFO[ListItem.Title]</value>
     </variable>
 
@@ -184,7 +189,7 @@
     <variable name="Label_Title">
         <value condition="Container.Content(songs)">$INFO[ListItem.Artist]</value>
         <value condition="!String.IsEmpty(ListItem.Title)">$INFO[ListItem.Title]</value>
-        <value>$INFO[ListItem.Label]</value>
+        <value>$VAR[Item_Label]</value>
     </variable>
 
     <variable name="Label_ExtraInfo_Icons">
@@ -226,7 +231,7 @@
         <!-- Fallback -->
         <value condition="!ListItem.IsCollection">$INFO[ListItem.Label2]</value>
     </variable>
-    
+
     <variable name="Label_Rating">
         <value condition="Skin.HasSetting(music.showuserratings) + String.IsEmpty(ListItem.Overlay) + [Container.Content(albums) | Container.Content(songs)] + !String.IsEmpty(ListItem.UserRating) + String.IsEqual(ListItem.UserRating,10)">9.9</value>
         <value condition="Skin.HasSetting(music.showuserratings) + String.IsEmpty(ListItem.Overlay) + [Container.Content(albums) | Container.Content(songs)] + !String.IsEmpty(ListItem.UserRating)">$INFO[ListItem.UserRating,,.0]</value>
@@ -374,7 +379,7 @@
         <value condition="!String.IsEmpty(Skin.String(StartupPlaylist))">$INFO[Skin.String(StartupPlaylist)]</value>
         <value>$LOCALIZE[31189]</value>
     </variable>
-    
+
     <variable name="Label_VideoHWDecoder">
         <value condition="Player.Process(videohwdecoder)">HW</value>
         <value>SW</value>
@@ -416,4 +421,114 @@
         <value condition="String.Contains(ListItem.MPAA,tv-y)">TV-Y</value>
         <value>NR</value>
     </variable>
+
+    <variable name="Episode_Key_Full">
+        <value condition="String.StartsWith(ListItem.Label,0x)">0x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,1x)">1x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,2x)">2x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,3x)">3x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,4x)">4x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,5x)">5x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,6x)">6x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,7x)">7x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,8x)">8x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,9x)">9x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,10x)">10x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,11x)">11x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,12x)">12x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,13x)">13x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,14x)">14x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,15x)">15x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,16x)">16x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,17x)">17x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,18x)">18x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,19x)">19x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,20x)">20x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,21x)">21x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,22x)">22x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,23x)">23x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,24x)">24x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,25x)">25x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,26x)">26x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,27x)">27x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,28x)">28x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,29x)">29x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,30x)">30x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,31x)">31x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,32x)">32x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,33x)">33x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,34x)">34x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,35x)">35x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,36x)">36x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,37x)">37x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,38x)">38x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,39x)">39x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,40x)">40x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,41x)">41x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,42x)">42x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,43x)">43x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,44x)">44x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,45x)">45x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,46x)">46x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,47x)">47x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,48x)">48x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,49x)">49x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,50x)">50x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,51x)">51x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,52x)">52x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,53x)">53x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,54x)">54x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,55x)">55x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,56x)">56x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,57x)">57x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,58x)">58x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,59x)">59x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,60x)">60x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,61x)">61x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,62x)">62x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,63x)">63x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,64x)">64x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,65x)">65x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,66x)">66x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,67x)">67x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,68x)">68x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,69x)">69x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,70x)">70x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,71x)">71x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,72x)">72x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,73x)">73x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,74x)">74x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,75x)">75x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,76x)">76x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,77x)">77x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,78x)">78x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,79x)">79x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,80x)">80x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,81x)">81x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,82x)">82x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,83x)">83x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,84x)">84x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,85x)">85x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,86x)">86x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,87x)">87x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,88x)">88x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,89x)">89x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,90x)">90x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,91x)">91x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,92x)">92x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,93x)">93x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,94x)">94x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,95x)">95x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,96x)">96x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,97x)">97x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,98x)">98x$VAR[Episode_Key_Short]</value>
+        <value condition="String.StartsWith(ListItem.Label,99x)">99x$VAR[Episode_Key_Short]</value>
+        <value>$VAR[Episode_Key_Short]</value>
+    </variable>
+
+    <variable name="Episode_Key_Short">
+        <value condition="Integer.IsLess(ListItem.Episode,10)">0$INFO[ListItem.Episode,,.]</value>
+        <value>$INFO[ListItem.Episode,,.]</value>
+    </variable>
+
 </includes>

--- a/16x9/Includes_PVR.xml
+++ b/16x9/Includes_PVR.xml
@@ -381,14 +381,14 @@
                                     <centertop>25%</centertop>
                                     <height>30</height>
                                     <selectedcolor>ListLabel</selectedcolor>
-                                    <label>$INFO[ListItem.Label]</label>
+                                    <label>$VAR[Item_Label]</label>
                                     <visible>!String.IsEmpty(ListItem.Label2)</visible>
                                 </control>
                                 <control type="label">
                                     <centertop>50%</centertop>
                                     <height>30</height>
                                     <selectedcolor>ListLabel</selectedcolor>
-                                    <label>$INFO[ListItem.Label]</label>
+                                    <label>$VAR[Item_Label]</label>
                                     <visible>String.IsEmpty(ListItem.Label2)</visible>
                                 </control>
                                 <control type="label">
@@ -436,7 +436,7 @@
                                     <height>30</height>
                                     <selectedcolor>Selected</selectedcolor>
                                     <textcolor>Selected</textcolor>
-                                    <label>$INFO[ListItem.Label]</label>
+                                    <label>$VAR[Item_Label]</label>
                                     <visible>!String.IsEmpty(ListItem.Label2)</visible>
                                 </control>
                                 <control type="label">
@@ -444,7 +444,7 @@
                                     <height>30</height>
                                     <selectedcolor>Selected</selectedcolor>
                                     <textcolor>Selected</textcolor>
-                                    <label>$INFO[ListItem.Label]</label>
+                                    <label>$VAR[Item_Label]</label>
                                     <visible>String.IsEmpty(ListItem.Label2)</visible>
                                 </control>
                                 <control type="label">

--- a/16x9/Includes_Window.xml
+++ b/16x9/Includes_Window.xml
@@ -188,7 +188,7 @@
                             <right>80</right>
                             <top>0</top>
                             <bottom>0</bottom>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                         </control>
                     </itemlayout>
                     <focusedlayout width="hubitemw" height="90">
@@ -212,7 +212,7 @@
                             <top>0</top>
                             <bottom>0</bottom>
                             <textcolor>Selected</textcolor>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                         </control>
                     </focusedlayout>
                     <content><include>$PARAM[categories]</include></content>
@@ -684,7 +684,7 @@
                             <align>left</align>
                             <font>Font-ListInfo-Small</font>
                             <textcolor>ListLabel</textcolor>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                             <selectedcolor>ListLabel</selectedcolor>
                         </control>
                         <control type="label">
@@ -718,7 +718,7 @@
                                 <align>left</align>
                                 <font>Font-ListInfo-Small</font>
                                 <textcolor>ListLabel</textcolor>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                                 <selectedcolor>ListLabel</selectedcolor>
                             </control>
                             <control type="label">
@@ -756,7 +756,7 @@
                                 <align>left</align>
                                 <font>Font-ListInfo-Small</font>
                                 <textcolor>Selected</textcolor>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                                 <selectedcolor>Selected</selectedcolor>
                             </control>
                             <control type="label">

--- a/16x9/LoginScreen.xml
+++ b/16x9/LoginScreen.xml
@@ -57,7 +57,7 @@
                             <aligny>center</aligny>
                         </control>
                         <control type="label">
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                             <font>Font-Button</font>
                             <left>bigpad</left>
                             <right>bigpad</right>
@@ -98,7 +98,7 @@
                             <textcolor>Selected</textcolor>
                         </control>
                         <control type="label">
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                             <font>Font-Button</font>
                             <left>bigpad</left>
                             <right>bigpad</right>

--- a/16x9/MyPVRGuide.xml
+++ b/16x9/MyPVRGuide.xml
@@ -34,7 +34,7 @@
                                 <align>left</align>
                                 <aligny>top</aligny>
                                 <font>Font-OSD</font>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                                 <textcolor>SideArrow</textcolor>
                             </control>
                         </itemlayout>
@@ -44,7 +44,7 @@
                                 <align>left</align>
                                 <aligny>top</aligny>
                                 <font>Font-OSD</font>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                                 <textcolor>LineLabel</textcolor>
                                 <visible>!Control.HasFocus(11)</visible>
                             </control>
@@ -54,7 +54,7 @@
                                 <align>left</align>
                                 <aligny>top</aligny>
                                 <font>Font-ListInfo-Small-Bold</font>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                                 <textcolor>$VAR[HighlightColor2]</textcolor>
                                 <visible>Control.HasFocus(11)</visible>
                             </control>
@@ -80,7 +80,7 @@
                                 <align>left</align>
                                 <aligny>top</aligny>
                                 <font>Font-OSD</font>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                                 <textcolor>ListLabel</textcolor>
                             </control>
                         </rulerlayout>
@@ -212,7 +212,7 @@
                                 <width>285</width>
                                 <textoffsetx>50</textoffsetx>
                                 <textcolor>ListLabel</textcolor>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                                 <visible>ListItem.HasTimer | ListItem.IsRecording</visible>
                             </control>
                             <control type="label" id="1">
@@ -221,7 +221,7 @@
                                 <height>67</height>
                                 <textcolor>ListLabel</textcolor>
                                 <textoffsetx>0</textoffsetx>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                                 <visible>!ListItem.HasTimer + !ListItem.IsRecording</visible>
                             </control>
                         </itemlayout>
@@ -274,7 +274,7 @@
                                 <width>285</width>
                                 <textoffsetx>50</textoffsetx>
                                 <textcolor>Selected</textcolor>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                                 <visible>ListItem.HasTimer | ListItem.IsRecording</visible>
                             </control>
                             <control type="label" id="1">
@@ -283,7 +283,7 @@
                                 <height>67</height>
                                 <textcolor>Selected</textcolor>
                                 <textoffsetx>0</textoffsetx>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                                 <visible>!ListItem.HasTimer + !ListItem.IsRecording</visible>
                             </control>
                         </focusedlayout>

--- a/16x9/SkinSettings.xml
+++ b/16x9/SkinSettings.xml
@@ -9,7 +9,7 @@
     <onload condition="Skin.HasSetting(EnableColorFilter) + String.IsEmpty(Skin.String(global.background))">Skin.SetString(global.background,special://skin/extras/backgrounds/overlays/pattern0.jpg)</onload>
     <onunload>RunScript(script.skinshortcuts,type=buildxml&amp;mainmenuID=9000&amp;group=mainmenu|x1101|x1102|x1103|x1104|x1105|x1106|x1107|x1108|x1109|x1111|x1112|x1113|x1114|x1115|x1116|x1117|x1118|x1119|powermenu)</onunload>
     <include condition="!Skin.HasSetting(store_init)">Defs_Store_Init</include>
-    
+
     <controls>
         <include>Furniture_Background</include>
         <include>Furniture_TopBar</include>
@@ -198,7 +198,7 @@
                             <include>Defs_OptionButton</include>
                             <visible>ControlGroup(8000).HasFocus(8001)</visible>
                         </control>
-                        
+
                         <!-- Widget Info Box -->
                         <control type="radiobutton" id="8105">
                             <width>100%</width>
@@ -284,8 +284,8 @@
                             <include>Defs_OptionButton</include>
                             <visible>ControlGroup(8000).HasFocus(8001)</visible>
                         </control>
-                        
-                        
+
+
 
 
                         <!-- Div HEADER -->
@@ -956,6 +956,17 @@
                             <include>Defs_OptionButton</include>
                             <visible>ControlGroup(8000).HasFocus(8005)</visible>
                         </control>
+                        <!-- Show Unwatched Episode Names -->
+                        <control type="radiobutton" id="9000">
+                            <radioposx>settingsradioposx</radioposx>
+                            <width>100%</width>
+                            <label>31284</label>
+                            <selected>Skin.HasSetting(furniture.showunwatchedepisodenames)</selected>
+                            <onclick>Skin.ToggleSetting(furniture.showunwatchedepisodenames)</onclick>
+                            <height>72</height>
+                            <include>Defs_OptionButton</include>
+                            <visible>ControlGroup(8000).HasFocus(8005)</visible>
+                        </control>
                         <!-- Switch Positions -->
                         <control type="radiobutton" id="8516">
                             <radioposx>settingsradioposx</radioposx>
@@ -1034,9 +1045,6 @@
                             <include>Defs_OptionButton</include>
                             <visible>ControlGroup(8000).HasFocus(8005)</visible>
                         </control>
-                        
-                        
-
                         <!-- INSTALL -->
                         <control type="label" id="8699">
                             <width>100%</width>
@@ -1275,7 +1283,7 @@
                             <include>Defs_OptionButton</include>
                             <visible>ControlGroup(8000).HasFocus(8009)</visible>
                         </control>
-                        
+
                         <control type="radiobutton" id="8918">
                             <radioposx>settingsradioposx</radioposx>
                             <width>100%</width>

--- a/16x9/SkinSettings.xml
+++ b/16x9/SkinSettings.xml
@@ -957,11 +957,11 @@
                             <visible>ControlGroup(8000).HasFocus(8005)</visible>
                         </control>
                         <!-- Show Unwatched Episode Names -->
-                        <control type="radiobutton" id="9000">
+                        <control type="radiobutton" id="8960">
                             <radioposx>settingsradioposx</radioposx>
                             <width>100%</width>
                             <label>31284</label>
-                            <selected>Skin.HasSetting(furniture.showunwatchedepisodenames)</selected>
+                            <selected>!Skin.HasSetting(furniture.showunwatchedepisodenames)</selected>
                             <onclick>Skin.ToggleSetting(furniture.showunwatchedepisodenames)</onclick>
                             <height>72</height>
                             <include>Defs_OptionButton</include>

--- a/16x9/Viewtype_BigIcon.xml
+++ b/16x9/Viewtype_BigIcon.xml
@@ -126,7 +126,7 @@
                         <height>auto</height>
                         <align>left</align>
                         <font>Font-InfoBox-Title</font>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                     </control>
 
                     <control type="label">
@@ -264,7 +264,7 @@
                         <height>44</height>
                         <align>center</align>
                         <font>Font-InfoBox-Title</font>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                     </control>
                     <control type="label">
                         <height>32</height>
@@ -365,7 +365,7 @@
                             <height>auto</height>
                             <align>left</align>
                             <font>Font-InfoBox-Title</font>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                         </control>
 
                         <control type="textbox">

--- a/16x9/Viewtype_Icon.xml
+++ b/16x9/Viewtype_Icon.xml
@@ -133,7 +133,7 @@
                             <top>pad</top>
                             <bottom>100</bottom>
                             <control type="textbox">
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                                 <font>Font-OSD</font>
                                 <align>center</align>
                                 <height>64</height>
@@ -200,7 +200,7 @@
                                 <texture background="true" colordiffuse="PosterBorder">common/white.png</texture>
                             </control>
                             <control type="label">
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                                 <align>center</align>
                                 <left>pad</left>
                                 <right>pad</right>
@@ -220,7 +220,7 @@
                             <top>pad</top>
                             <bottom>100</bottom>
                             <control type="textbox">
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                                 <font>Font-OSD</font>
                                 <align>center</align>
                                 <height>64</height>
@@ -288,7 +288,7 @@
                                 <texture background="true" colordiffuse="$VAR[HighlightColor]">common/white.png</texture>
                             </control>
                             <control type="label">
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                                 <align>center</align>
                                 <left>pad</left>
                                 <right>pad</right>
@@ -502,7 +502,7 @@
                                 <bottom>pad</bottom>
                                 <height>48</height>
                                 <font>Font-ListInfo-Small-Bold</font>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                             </control>
                             <control type="label">
                                 <left>25</left>
@@ -560,7 +560,7 @@
                                 <height>48</height>
                                 <textcolor>Selected</textcolor>
                                 <font>Font-ListInfo-Small-Bold</font>
-                                <label>$INFO[ListItem.Label]</label>
+                                <label>$VAR[Item_Label]</label>
                             </control>
                             <control type="label">
                                 <left>25</left>

--- a/16x9/Viewtype_List.xml
+++ b/16x9/Viewtype_List.xml
@@ -415,7 +415,7 @@
                     <height>36</height>
                     <textcolor>ListLabel</textcolor>
                     <font>Font-InfoBox-Title</font>
-                    <label>$INFO[ListItem.Label]</label>
+                    <label>$VAR[Item_Label]</label>
                 </control>
                 <control type="label">
                     <top>70</top>
@@ -527,7 +527,7 @@
                                     <height>36</height>
                                     <textcolor>Selected</textcolor>
                                     <font>Font-InfoBox-Title</font>
-                                    <label>$INFO[ListItem.Label]</label>
+                                    <label>$VAR[Item_Label]</label>
                                 </control>
                                 <control type="label">
                                     <top>70</top>
@@ -642,7 +642,7 @@
                     <top>0</top>
                     <height>100%</height>
                     <textcolor>ListLabel</textcolor>
-                    <label>$INFO[ListItem.Label]</label>
+                    <label>$VAR[Item_Label]</label>
                     <visible>Container.Content(movies)</visible>
                 </control>
                 <control type="label">
@@ -651,7 +651,7 @@
                     <top>0</top>
                     <height>100%</height>
                     <textcolor>ListLabel</textcolor>
-                    <label>$INFO[ListItem.Label]</label>
+                    <label>$VAR[Item_Label]</label>
                     <visible>!Container.Content(movies)</visible>
                 </control>
 
@@ -759,7 +759,7 @@
                     <top>0</top>
                     <height>100%</height>
                     <textcolor>ListLabel</textcolor>
-                    <label>$INFO[ListItem.Label]</label>
+                    <label>$VAR[Item_Label]</label>
                     <visible>!String.IsEmpty(ListItem.Overlay) + $PARAM[label2]</visible>
                 </control>
                 <control type="label">
@@ -768,7 +768,7 @@
                     <top>0</top>
                     <height>100%</height>
                     <textcolor>ListLabel</textcolor>
-                    <label>$INFO[ListItem.Label]</label>
+                    <label>$VAR[Item_Label]</label>
                     <visible>String.IsEmpty(ListItem.Overlay) | !$PARAM[label2]</visible>
                 </control>
 
@@ -821,7 +821,7 @@
                     <top>0</top>
                     <height>100%</height>
                     <textcolor>Selected</textcolor>
-                    <label>$INFO[ListItem.Label]</label>
+                    <label>$VAR[Item_Label]</label>
                     <visible>Container.Content(movies)</visible>
                 </control>
                 <control type="label">
@@ -830,7 +830,7 @@
                     <top>0</top>
                     <height>100%</height>
                     <textcolor>Selected</textcolor>
-                    <label>$INFO[ListItem.Label]</label>
+                    <label>$VAR[Item_Label]</label>
                     <visible>!Container.Content(movies)</visible>
                 </control>
 
@@ -927,7 +927,7 @@
                     <top>0</top>
                     <height>100%</height>
                     <textcolor>Selected</textcolor>
-                    <label>$INFO[ListItem.Label]</label>
+                    <label>$VAR[Item_Label]</label>
                     <visible>!String.IsEmpty(ListItem.Overlay) + $PARAM[label2]</visible>
                 </control>
                 <control type="label">
@@ -936,7 +936,7 @@
                     <top>0</top>
                     <height>100%</height>
                     <textcolor>Selected</textcolor>
-                    <label>$INFO[ListItem.Label]</label>
+                    <label>$VAR[Item_Label]</label>
                     <visible>String.IsEmpty(ListItem.Overlay) | !$PARAM[label2]</visible>
                 </control>
 
@@ -1023,7 +1023,7 @@
             <top>0</top>
             <height>70%</height>
             <textcolor>ListLabel</textcolor>
-            <label>$INFO[ListItem.Label]</label>
+            <label>$VAR[Item_Label]</label>
             <visible>!String.IsEmpty(ListItem.Label2)</visible>
         </control>
         <control type="label">
@@ -1032,7 +1032,7 @@
             <top>0</top>
             <height>100%</height>
             <textcolor>ListLabel</textcolor>
-            <label>$INFO[ListItem.Label]</label>
+            <label>$VAR[Item_Label]</label>
             <visible>String.IsEmpty(ListItem.Label2)</visible>
         </control>
     </include>
@@ -1066,7 +1066,7 @@
             <top>0</top>
             <height>70%</height>
             <textcolor>Selected</textcolor>
-            <label>$INFO[ListItem.Label]</label>
+            <label>$VAR[Item_Label]</label>
             <visible>!String.IsEmpty(ListItem.Label2)</visible>
         </control>
         <control type="label">
@@ -1075,7 +1075,7 @@
             <top>0</top>
             <height>100%</height>
             <textcolor>Selected</textcolor>
-            <label>$INFO[ListItem.Label]</label>
+            <label>$VAR[Item_Label]</label>
             <visible>String.IsEmpty(ListItem.Label2)</visible>
         </control>
     </include>

--- a/16x9/Viewtype_ShowCase.xml
+++ b/16x9/Viewtype_ShowCase.xml
@@ -390,7 +390,7 @@
                             <height>44</height>
                             <align>center</align>
                             <font>Font-InfoBox-Title</font>
-                            <label>$INFO[ListItem.Label]</label>
+                            <label>$VAR[Item_Label]</label>
                         </control>
                         <control type="label">
                             <left>pad</left>

--- a/16x9/script-skinshortcuts.xml
+++ b/16x9/script-skinshortcuts.xml
@@ -39,7 +39,7 @@
                         <right>30</right>
                         <top>0</top>
                         <height>100%</height>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                         <visible>String.IsEqual(Window.Property(groupname),powermenu)</visible>
                     </control>
                     <control type="label">
@@ -47,7 +47,7 @@
                         <right>30</right>
                         <top>0</top>
                         <height>100%</height>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                         <visible>!String.IsEqual(Window.Property(groupname),powermenu)</visible>
                     </control>
                     <control type="image">
@@ -73,7 +73,7 @@
                         <right>30</right>
                         <top>0</top>
                         <height>100%</height>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                         <textcolor>Selected</textcolor>
                         <visible>String.IsEqual(Window.Property(groupname),powermenu)</visible>
                     </control>
@@ -82,7 +82,7 @@
                         <right>30</right>
                         <top>0</top>
                         <height>100%</height>
-                        <label>$INFO[ListItem.Label]</label>
+                        <label>$VAR[Item_Label]</label>
                         <textcolor>Selected</textcolor>
                         <visible>!String.IsEqual(Window.Property(groupname),powermenu)</visible>
                     </control>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1220,3 +1220,8 @@ msgstr ""
 msgctxt "#31283"
 msgid "Fallback image"
 msgstr ""
+
+#: /16x9/SkinSettings.xml
+msgctxt "#31284"
+msgid "Show name of unwatched episodes"
+msgstr ""


### PR DESCRIPTION
This pull request adds an option to not display or not the names of series episodes that have not yet been viewed. By default, episode names are always enabled, which retains the current behavior.

This option supplements the basic option included in Kodi to hide summaries or fanart of these episodes. It would be more logical to include this option in the base kodi but the development team rejected my pr which does not correspond to their vision of the application. So I added the option in the skin I use. I think this option is very useful for many users.

![image1](https://user-images.githubusercontent.com/46631671/177598884-af7b569d-6530-47ad-80ed-f9d0b4f2d6b3.jpg)
![image2](https://user-images.githubusercontent.com/46631671/177598886-cbc18d20-087e-48d8-8c57-42894faccdc9.jpg)
![image3](https://user-images.githubusercontent.com/46631671/177598891-8ea89970-ecae-48b2-b645-1e422919ed0a.jpg)
![image4](https://user-images.githubusercontent.com/46631671/177598898-9f22da54-6e08-4d40-aabc-bbbf9b9570f8.jpg)